### PR TITLE
Add aiohttp to requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 version = '0.6'
 
-REQUIREMENTS = ['xmltodict']
+REQUIREMENTS = ['xmltodict', 'aiohttp']
 
 CLASSIFIERS = [
     'Development Status :: 2 - Pre-Alpha',


### PR DESCRIPTION
We experienced an issue in realtime that the package could not build
because `cannot import name 'HttpProcessingError' from 'aiohttp'`. I
think the solution is to add it to these requirements ...